### PR TITLE
Literate CoffeeScript files support added #2

### DIFF
--- a/src/coffee-cash.coffee
+++ b/src/coffee-cash.coffee
@@ -42,7 +42,10 @@ loadCoffeeScript = ->
 
 compileCoffeeScript = (coffee, filePath, cachePath) ->
   CoffeeScript ?= loadCoffeeScript()
-  {js, v3SourceMap} = CoffeeScript.compile(coffee, filename: filePath, sourceMap: true)
+  {js, v3SourceMap} = CoffeeScript.compile coffee,
+    filename: filePath
+    sourceMap: true
+    literate: ///\.(litcoffee|coffee.md)$///.test(filePath)
   stats.misses++
 
   if btoa? and unescape? and encodeURIComponent?


### PR DESCRIPTION
Now `.litcoffee` and `.coffee.md` files are compiled with `literate` flag.
