### PR TITLE
Remove dependency on fs-plus to reduce load time

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     }
   ],
   "dependencies": {
-    "coffee-script": "1.8.0",
-    "fs-plus": "^2.5.0"
+    "coffee-script": "^1.8.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/src/coffee-cash.coffee
+++ b/src/coffee-cash.coffee
@@ -1,8 +1,8 @@
 crypto = require 'crypto'
+fs = require 'fs'
 path = require 'path'
 
 CoffeeScript = null # defer until used
-fs = require 'fs-plus'
 
 stats =
   hits: 0
@@ -14,7 +14,7 @@ getCachePath = (coffee) ->
   path.join(cacheDirectory, "#{digest}.js")
 
 getCachedJavaScript = (cachePath) ->
-  if fs.isFileSync(cachePath)
+  if (try fs.statSync(cachePath).isFile())
     try
       cachedJavaScript = fs.readFileSync(cachePath, 'utf8')
       stats.hits++


### PR DESCRIPTION
This PR improves the responsiveness of `coffee-cash` by removing its dependency on `fs-plus`. It also expands the version range of the `coffee-script` dependency to include 1.9, 1.10 &c. (1.8.0 is [over a year old](http://coffeescript.org/#changelog)).

In my particular use case, this yields a speedup of ~20 ms (15% of the total execution time, including node's slow startup, and > 50% of the application execution time). This is unlikely to be significant in Atom, but it can make a [huge difference](http://www.nngroup.com/articles/response-times-3-important-limits/) on the command line.

```
$ cat ./profile.js
```

``` javascript
require('time-require')
require('coffee-cash')
```

```
$ node ./profile.js
```

![time-require](https://i.imgur.com/cVMEb6P.jpg)
